### PR TITLE
increase jvm memory size for mill

### DIFF
--- a/.mill-jvm-opts
+++ b/.mill-jvm-opts
@@ -1,2 +1,2 @@
 -Xms50M
--Xmx256M
+-Xmx512M


### PR DESCRIPTION
I got an OutOfMemory Exception with 256m, so I increased it back to 512m.
